### PR TITLE
If exec() fails, abort child with an error message.

### DIFF
--- a/lib/Arctica/Core/Mother/Forker.pm
+++ b/lib/Arctica/Core/Mother/Forker.pm
@@ -253,6 +253,8 @@ sub _afork_ipty {
 #		DONE dealing with ENV here.
 
 		exec($self->{'exec_path'},@cl_args);
+		BugOUT(0, "Failed to execute " . $self->{'exec_path'} . " " . join(' ', @cl_args) . ": $!");
+		exit(1);
 
 	# END OF THE FORKING CHILD
 	}


### PR DESCRIPTION
Noticed this issue while looking at the code.